### PR TITLE
Remove api_config.json and use environment variable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+AuditWifiApp/config/api_config.json
+

--- a/AuditWifiApp/README.md
+++ b/AuditWifiApp/README.md
@@ -124,6 +124,17 @@ L'application utilise l'API OpenAI de manière simple et directe via deux points
 
 La réponse d'OpenAI est affichée directement dans l'interface, sans traitement supplémentaire. Cela permet une lecture facile des recommandations et une meilleure compréhension du raisonnement de l'IA.
 
+### Configuration de la clé API
+
+La clé d'accès à l'API OpenAI est désormais lue uniquement depuis la variable d'environnement `OPENAI_API_KEY`. Avant de lancer l'application ou les tests, définissez cette variable :
+
+```powershell
+$env:OPENAI_API_KEY="votre-cle"
+python runner.py
+```
+
+Le fichier `config/api_config.json` n'est plus utilisé et peut être ignoré.
+
 ## Questions pour clarifier le besoin
 
 1. **Concernant l'intégration avec l'API OpenAI:**

--- a/AuditWifiApp/config/api_config.json
+++ b/AuditWifiApp/config/api_config.json
@@ -1,3 +1,0 @@
-{
-  "api_key": "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"
-}

--- a/AuditWifiApp/runner.py
+++ b/AuditWifiApp/runner.py
@@ -205,40 +205,14 @@ class NetworkAnalyzerUI:
                 )
                 return
 
-            # Vérifier la clé API OpenAI dans différentes sources
+            # Vérifier la clé API OpenAI dans l'environnement
             api_key = os.getenv("OPENAI_API_KEY")
-            
-            # Si pas dans les variables d'environnement, chercher dans le fichier de config
             if not api_key:
-                config_file = os.path.join(os.path.dirname(__file__), "config", "api_config.json")
-                if os.path.exists(config_file):
-                    try:
-                        with open(config_file, 'r') as f:
-                            config = json.load(f)
-                            api_key = config.get('api_key')
-                    except:
-                        pass
-
-            # Si toujours pas de clé, demander à l'utilisateur
-            if not api_key:
-                result = messagebox.askyesno(
-                    "Configuration requise",
-                    "La clé API OpenAI n'est pas configurée. Voulez-vous la configurer maintenant ?"
+                messagebox.showerror(
+                    "Clé API manquante",
+                    "La variable d'environnement OPENAI_API_KEY doit être définie pour utiliser l'analyse OpenAI."
                 )
-                if result:
-                    api_key = self.prompt_for_api_key()
-                    if not api_key:
-                        return
-                    
-                    # Sauvegarder la clé dans le fichier de config
-                    config_dir = os.path.join(os.path.dirname(__file__), "config")
-                    os.makedirs(config_dir, exist_ok=True)
-                    with open(os.path.join(config_dir, "api_config.json"), 'w') as f:
-                        json.dump({"api_key": api_key}, f, indent=2)
-                    
-                    os.environ["OPENAI_API_KEY"] = api_key
-                else:
-                    return
+                return
 
             # Mise à jour de l'interface
             self.moxa_results.delete('1.0', tk.END)
@@ -291,35 +265,6 @@ class NetworkAnalyzerUI:
         finally:
             self.analyze_button.config(state=tk.NORMAL)
 
-    def prompt_for_api_key(self):
-        """Demande à l'utilisateur sa clé API OpenAI"""
-        api_key = None
-        dialog = tk.Toplevel(self.master)
-        dialog.title("Configuration OpenAI")
-        dialog.transient(self.master)
-        dialog.grab_set()
-        
-        # Centrer la fenêtre
-        dialog.geometry("400x150")
-        
-        ttk.Label(dialog, text="Entrez votre clé API OpenAI:").pack(pady=10)
-        api_key_var = tk.StringVar()
-        entry = ttk.Entry(dialog, textvariable=api_key_var, width=50)
-        entry.pack(pady=5, padx=10)
-        
-        def submit():
-            nonlocal api_key
-            api_key = api_key_var.get().strip()
-            dialog.destroy()
-            
-        def cancel():
-            dialog.destroy()
-        
-        ttk.Button(dialog, text="OK", command=submit).pack(side=tk.LEFT, padx=10, pady=10)
-        ttk.Button(dialog, text="Annuler", command=cancel).pack(side=tk.RIGHT, padx=10, pady=10)
-        
-        dialog.wait_window()
-        return api_key
 
     def format_and_display_ai_analysis(self, analysis: str):
         """Formate et affiche l'analyse OpenAI dans l'interface"""

--- a/AuditWifiApp/src/ai/simple_moxa_analyzer.py
+++ b/AuditWifiApp/src/ai/simple_moxa_analyzer.py
@@ -40,31 +40,13 @@ def truncate_logs(logs, max_length=8000):
     return f"{logs[:half_length]}\n...[LOGS TRONQUÉS]...\n{logs[-half_length:]}"
 
 def get_api_key():
-    """
-    Récupère la clé API OpenAI depuis les différentes sources possibles.
-    Ordre de priorité:
-    1. Variable d'environnement OPENAI_API_KEY
-    2. Fichier de configuration config/api_config.json
-    """
-    # Vérifier la variable d'environnement
+    """Retourne la clé API OpenAI depuis la variable d'environnement."""
     api_key = os.getenv("OPENAI_API_KEY")
-    if api_key:
-        return api_key
-    
-    # Chercher dans le fichier de configuration
-    try:
-        config_path = Path(__file__).parents[3] / "config" / "api_config.json"
-        if config_path.exists():
-            with open(config_path, 'r') as f:
-                config = json.load(f)
-                if "api_key" in config:
-                    # Définir la variable d'environnement pour les futurs appels
-                    os.environ["OPENAI_API_KEY"] = config["api_key"]
-                    return config["api_key"]
-    except Exception as e:
-        print(f"Warning: Could not read API key from config file: {e}")
-    
-    return None
+    if not api_key:
+        raise Exception(
+            "Clé API OpenAI non trouvée. Définissez la variable d'environnement OPENAI_API_KEY."
+        )
+    return api_key
 
 def analyze_moxa_logs(logs, current_config):
     """
@@ -81,8 +63,6 @@ def analyze_moxa_logs(logs, current_config):
         raise ValueError("Les logs sont vides")
         
     api_key = get_api_key()
-    if not api_key:
-        raise Exception("Clé API OpenAI non trouvée. Veuillez configurer la variable d'environnement OPENAI_API_KEY ou le fichier config/api_config.json")
 
     # Tronquer les logs si nécessaire
     truncated_logs = truncate_logs(logs)


### PR DESCRIPTION
## Summary
- remove `AuditWifiApp/config/api_config.json` from version control
- rely only on environment variable `OPENAI_API_KEY` in `simple_moxa_analyzer` and `runner`
- document new key configuration method in README
- ignore `AuditWifiApp/config/api_config.json` via `.gitignore`

## Testing
- `pytest -q` *(fails: command not found)*