### PR TITLE
Configure Codex setup

### DIFF
--- a/.codex/setup.sh
+++ b/.codex/setup.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# Setup script for Codex environment
+# Installs Python dependencies using requirements.txt
+set -e
+
+# Navigate to repository root
+cd "$(dirname "$0")/.."
+
+if [ -d packages ]; then
+    pip install --no-index --find-links packages -r requirements.txt
+else
+    pip install -r requirements.txt
+fi


### PR DESCRIPTION
## Summary
- add `.codex/setup.sh` so the Codex container installs dependencies

## Testing
- `bash .codex/setup.sh` *(fails: Could not connect to package index)*
- `pytest -q` *(fails: command not found)*