### PR TITLE
Implement .env support for API key

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 AuditWifiApp/config/api_config.json
+.env
 

--- a/AuditWifiApp/README.md
+++ b/AuditWifiApp/README.md
@@ -126,12 +126,13 @@ La réponse d'OpenAI est affichée directement dans l'interface, sans traitement
 
 ### Configuration de la clé API
 
-La clé d'accès à l'API OpenAI est désormais lue uniquement depuis la variable d'environnement `OPENAI_API_KEY`. Avant de lancer l'application ou les tests, définissez cette variable :
+Créez un fichier `.env` à la racine du projet pour stocker la clé API :
 
-```powershell
-$env:OPENAI_API_KEY="votre-cle"
-python runner.py
+```dotenv
+OPENAI_API_KEY=votre-cle
 ```
+
+Ce fichier est ignoré par Git. L'application charge automatiquement cette valeur avec `python-dotenv`.
 
 Le fichier `config/api_config.json` n'est plus utilisé et peut être ignoré.
 

--- a/AuditWifiApp/runner.py
+++ b/AuditWifiApp/runner.py
@@ -11,6 +11,10 @@ from matplotlib.figure import Figure
 import numpy as np
 from typing import List, Optional
 import os
+from dotenv import load_dotenv
+
+# Charger automatiquement les variables d'environnement depuis un fichier .env
+load_dotenv()
 
 from network_analyzer import NetworkAnalyzer
 from wifi.wifi_collector import WifiSample

--- a/README.md
+++ b/README.md
@@ -12,10 +12,11 @@ AuditWifiApp is a Python application for auditing Wi-Fi coverage in factories. I
    ./setup.ps1
    ```
    On Linux/macOS you can run `bash setup.sh` instead.
-3. Set your OpenAI API key:
-   ```powershell
-   $env:OPENAI_API_KEY="your-key"
+3. Create a `.env` file at the project root containing your API key:
    ```
+   OPENAI_API_KEY=your-key
+   ```
+   The file is ignored by Git so your key persists locally.
 4. Launch the user interface:
    ```bash
    python AuditWifiApp/runner.py


### PR DESCRIPTION
## Summary
- autoload environment variables from `.env`
- ignore `.env`
- document persistent API key setup in both READMEs

## Testing
- `pytest -q` *(fails: ImportError: cannot import name 'MoxaAnalyzerUI' from 'runner')*