### PR TITLE
Add SNR metrics

### DIFF
--- a/AuditWifiApp/models/measurement_record.py
+++ b/AuditWifiApp/models/measurement_record.py
@@ -17,14 +17,18 @@ class NetworkStatus(Enum):
 @dataclass
 class WifiMeasurement:
     """Mesure WiFi à un instant donné"""
-    bssid: str
     ssid: str
-    signal_strength: int
+    bssid: str
+    signal_percent: int
+    signal_dbm: int
     channel: int
-    frequency: str
     band: str
-    encryption: str
-    network_type: str
+    frequency: str
+    frequency_mhz: int
+    is_connected: bool
+    channel_utilization: float
+    noise_floor: Optional[int] = None
+    snr: Optional[int] = None
 
 @dataclass
 class PingMeasurement:

--- a/AuditWifiApp/tests/test_wifi_metrics.py
+++ b/AuditWifiApp/tests/test_wifi_metrics.py
@@ -1,0 +1,49 @@
+import json
+from unittest.mock import patch, MagicMock
+
+from wifi.powershell_collector import PowerShellWiFiCollector
+from wifi.wifi_analyzer import WifiAnalyzer
+from models.measurement_record import WifiMeasurement
+
+
+def test_collector_parses_noise_and_snr():
+    collector = PowerShellWiFiCollector()
+    ps_output = json.dumps({
+        "SSID": "TestNet",
+        "SignalStrength": "70%",
+        "SignalStrengthDBM": -65,
+        "NoiseFloor": -90,
+        "SNR": 25,
+        "Channel": 6
+    })
+    fake_result = MagicMock(returncode=0, stdout=ps_output)
+    with patch('subprocess.run', return_value=fake_result):
+        data = collector.get_wifi_data()
+
+    assert data["NoiseFloor"] == -90
+    assert data["SNR"] == 25
+
+
+def test_analyzer_evaluates_snr():
+    analyzer = WifiAnalyzer()
+    metrics = analyzer._analyze_metrics({"rssi": -60, "snr": 12, "ping": 10, "packet_loss": 0})
+    assert metrics["snr_quality"] == "Moyen"
+
+
+def test_wifi_measurement_stores_noise_and_snr():
+    m = WifiMeasurement(
+        ssid="t",
+        bssid="00:11",
+        signal_percent=50,
+        signal_dbm=-70,
+        channel=1,
+        band="2.4 GHz",
+        frequency="2.4 GHz",
+        frequency_mhz=2412,
+        is_connected=True,
+        channel_utilization=0.1,
+        noise_floor=-95,
+        snr=25
+    )
+    assert m.noise_floor == -95
+    assert m.snr == 25

--- a/AuditWifiApp/wifi/powershell_collector.py
+++ b/AuditWifiApp/wifi/powershell_collector.py
@@ -63,11 +63,39 @@ class PowerShellWiFiCollector:
                     return None
 
                 # Normaliser les noms des champs
+                signal_raw = wifi_data.get("SignalStrength", wifi_data.get("Signal", 0))
+                signal_percent = int(str(signal_raw).replace("%", ""))
+                signal_dbm = wifi_data.get("SignalStrengthDBM")
+                if signal_dbm is None:
+                    signal_dbm = -100 + signal_percent * 0.5
+                else:
+                    try:
+                        signal_dbm = int(signal_dbm)
+                    except ValueError:
+                        signal_dbm = -100 + signal_percent * 0.5
+
+                noise_floor = wifi_data.get("NoiseFloor")
+                if noise_floor is not None:
+                    try:
+                        noise_floor = int(noise_floor)
+                    except ValueError:
+                        noise_floor = None
+
+                snr_val = wifi_data.get("SNR")
+                if snr_val is not None:
+                    try:
+                        snr_val = int(snr_val)
+                    except ValueError:
+                        snr_val = None
+
+                if snr_val is None and noise_floor is not None:
+                    snr_val = int(signal_dbm - noise_floor)
+
                 normalized_data = {
                     "SSID": wifi_data.get("SSID", "N/A"),
                     "BSSID": wifi_data.get("BSSID", "00:00:00:00:00:00"),
-                    "SignalStrength": str(wifi_data.get("Signal", 0)) + "%",
-                    "SignalStrengthDBM": -100 + int(wifi_data.get("Signal", 0)) * 0.5,
+                    "SignalStrength": f"{signal_percent}%",
+                    "SignalStrengthDBM": signal_dbm,
                     "Channel": wifi_data.get("Channel", "N/A"),
                     "Band": wifi_data.get("Band", "2.4 GHz"),
                     "Status": wifi_data.get("Status", "Déconnecté"),
@@ -75,7 +103,9 @@ class PowerShellWiFiCollector:
                     "ReceiveRate": wifi_data.get("ReceiveRate", "0 Mbps"),
                     "Authentication": wifi_data.get("Authentication", "N/A"),
                     "PingLatency": wifi_data.get("PingLatency", -1),
-                    "Gateway": wifi_data.get("Gateway", "N/A")
+                    "Gateway": wifi_data.get("Gateway", "N/A"),
+                    "NoiseFloor": noise_floor,
+                    "SNR": snr_val,
                 }
                 return normalized_data
 

--- a/AuditWifiApp/wifi/wifi_analyzer.py
+++ b/AuditWifiApp/wifi/wifi_analyzer.py
@@ -1,5 +1,5 @@
 import numpy as np
-from typing import List, Tuple, Dict
+from typing import List, Tuple, Dict, Optional
 from datetime import datetime
 from dataclasses import dataclass
 from .wifi_collector import WifiSample
@@ -31,6 +31,12 @@ class WifiAnalyzer:
             },
             "ping_ms": 50,
             "packet_loss_percent": 2,
+            "snr_db": {
+                "excellent": 25,
+                "good": 15,
+                "fair": 10,
+                "poor": 0,
+            },
         }
 
     def analyze_samples(self, samples: List[WifiSample]) -> WifiAnalysis:
@@ -203,6 +209,7 @@ class WifiAnalyzer:
         """Analyse les métriques WiFi principales."""
         return {
             "signal_quality": self._evaluate_signal_quality(wifi_data.get("rssi", 0)),
+            "snr_quality": self._evaluate_snr(wifi_data.get("snr")),
             "connection_stability": self._evaluate_connection_stability(
                 wifi_data.get("packet_loss", 0),
                 wifi_data.get("ping", 0),
@@ -213,6 +220,19 @@ class WifiAnalyzer:
                 "packet_loss": wifi_data.get("packet_loss", 0),
             },
         }
+
+    def _evaluate_snr(self, snr: Optional[int]) -> str:
+        """Évalue la qualité du SNR."""
+        if snr is None:
+            return "Inconnu"
+        if snr >= self.thresholds["snr_db"]["excellent"]:
+            return "Excellent"
+        elif snr >= self.thresholds["snr_db"]["good"]:
+            return "Bon"
+        elif snr >= self.thresholds["snr_db"]["fair"]:
+            return "Moyen"
+        else:
+            return "Faible"
 
     def _evaluate_signal_quality(self, rssi: float) -> str:
         """Évalue la qualité du signal basée sur le RSSI."""

--- a/AuditWifiApp/wifi_data_collector.py
+++ b/AuditWifiApp/wifi_data_collector.py
@@ -111,6 +111,13 @@ class WifiDataCollector:
             channel_val = int(wifi_data.get('Channel', '0'))
             band = wifi_data.get('Band', '2.4 GHz')  # Default to 2.4 GHz if not specified
 
+            noise_floor = wifi_data.get('NoiseFloor')
+            noise_floor = int(noise_floor) if noise_floor not in [None, ""] else None
+            snr_value = wifi_data.get('SNR')
+            snr_value = int(snr_value) if snr_value not in [None, ""] else None
+            if snr_value is None and noise_floor is not None:
+                snr_value = int(signal_dbm) - int(noise_floor)
+
             # Create measurement
             measurement = WifiMeasurement(
                 ssid=ssid,
@@ -122,7 +129,9 @@ class WifiDataCollector:
                 frequency=band,
                 frequency_mhz=_channel_to_frequency_mhz(channel_val),
                 is_connected=bool(ssid != 'N/A'),
-                channel_utilization=float(wifi_data.get('ChannelUtilization', '0').strip('%')) / 100
+                channel_utilization=float(wifi_data.get('ChannelUtilization', '0').strip('%')) / 100,
+                noise_floor=noise_floor,
+                snr=snr_value
             )
 
             self.logger.debug(f"Mesure WiFi créée: SSID={ssid}, "

--- a/AuditWifiApp/wifi_monitor.ps1
+++ b/AuditWifiApp/wifi_monitor.ps1
@@ -11,6 +11,8 @@ function Get-WifiStatus {
         Status            = "Disconnected"
         TransmitRate      = "0 Mbps"
         ReceiveRate       = "0 Mbps"
+        NoiseFloor        = $null
+        SNR               = $null
     }
 
     try {
@@ -66,6 +68,21 @@ function Get-WifiStatus {
                 }
                 if ($wifiInfo -match "Transmit rate \(Mbps\)\s*:\s*(\d+)") {
                     $result.TransmitRate = "$($matches[1]) Mbps"
+                }
+
+                # Noise floor if available
+                if ($wifiInfo -match "Noise\s*:\s*(-?\d+)\s*dBm") {
+                    $result.NoiseFloor = [int]$matches[1]
+                }
+
+                # SNR if provided directly
+                if ($wifiInfo -match "SNR\s*:\s*(\d+)\s*dB") {
+                    $result.SNR = [int]$matches[1]
+                }
+
+                # Compute SNR if not provided but noise and signal are present
+                if ($null -ne $result.NoiseFloor -and $null -eq $result.SNR) {
+                    $result.SNR = [int]($result.SignalStrengthDBM - $result.NoiseFloor)
                 }
             }
         }


### PR DESCRIPTION
## Summary
- parse optional noise floor and SNR in `wifi_monitor.ps1`
- expose the new fields from `PowerShellWiFiCollector`
- store noise floor and SNR in `WifiMeasurement`
- calculate SNR evaluation in `WifiAnalyzer`
- include noise metrics when building WifiMeasurement
- add tests for the new behaviour

## Testing
- `pytest -q`