### PR TITLE
Add validation for additional params in Moxa analyzer

### DIFF
--- a/AuditWifiApp/tests/test_moxa_analyzer.py
+++ b/AuditWifiApp/tests/test_moxa_analyzer.py
@@ -114,3 +114,35 @@ def test_additional_params_in_prompt(sample_moxa_logs):
 
     assert "roaming=snr" in captured["prompt"]
 
+
+def test_additional_params_too_long(sample_moxa_logs):
+    """Ensure validation triggers when params exceed length."""
+    long_params = "a" * 501
+    with pytest.raises(ValueError) as exc_info:
+        analyze_moxa_logs(sample_moxa_logs, {}, long_params)
+    assert "trop longs" in str(exc_info.value)
+
+
+def test_additional_params_sanitization(sample_moxa_logs):
+    """Non-printable characters should be removed from the prompt."""
+    captured = {}
+
+    def fake_post(url, headers=None, json=None, timeout=60):
+        captured["prompt"] = json["messages"][0]["content"]
+
+        class R:
+            status_code = 200
+
+            def json(self):
+                return {"choices": [{"message": {"content": "ok"}}]}
+
+        return R()
+
+    session = MagicMock()
+    session.post.side_effect = fake_post
+    with patch('src.ai.simple_moxa_analyzer.create_retry_session', return_value=session):
+        analyze_moxa_logs(sample_moxa_logs, {}, "abc\n\tdef")
+
+    assert "abcdef" in captured["prompt"]
+    assert "abc\n\tdef" not in captured["prompt"]
+


### PR DESCRIPTION
## Summary
- sanitize and validate `additional_params` in `simple_moxa_analyzer`
- test too-long additional params
- test stripping of non-printable characters

## Testing
- `pytest -q`