### PR TITLE
Enable automatic scan when starting collection

### DIFF
--- a/AuditWifiApp/runner.py
+++ b/AuditWifiApp/runner.py
@@ -283,6 +283,7 @@ class NetworkAnalyzerUI:
                 self.stop_button.config(state=tk.NORMAL)
                 self.update_data()
                 self.update_status("Collection en cours...")
+                self.scan_nearby_aps()
         except Exception as e:
             self.show_error(f"Erreur au démarrage: {str(e)}")
 

--- a/AuditWifiApp/tests/conftest.py
+++ b/AuditWifiApp/tests/conftest.py
@@ -134,6 +134,8 @@ def patch_ttk_style():
         def config(self, **kwargs):
             self.options.update(kwargs)
 
+        configure = config
+
         def __getitem__(self, key):
             return self.options.get(key)
 
@@ -143,6 +145,8 @@ def patch_ttk_style():
         patch('log_manager.messagebox'),
 
         patch('tkinter.Text'),
+        patch('tkinter.ttk.Treeview', DummyTreeview),
+        patch('tkinter.ttk.Button', DummyButton),
         patch('tkinter.ttk.OptionMenu'),
         patch('tkinter.Menu'),
         patch('matplotlib.backends.backend_tkagg.FigureCanvasTkAgg'),

--- a/AuditWifiApp/tests/test_network_scan_ui.py
+++ b/AuditWifiApp/tests/test_network_scan_ui.py
@@ -37,3 +37,14 @@ def test_export_scan_results(tmp_path, mock_tk_root):
         rows = list(csv.reader(f))
     assert rows[0] == ["SSID", "Signal(dBm)", "Canal", "Bande"]
     assert rows[1][0] == "AP1"
+
+
+def test_start_collection_triggers_scan(mock_tk_root):
+    """start_collection should scan WiFi networks after starting."""
+    with patch("runner.scan_wifi") as mock_scan, \
+         patch.object(NetworkAnalyzerUI, "update_data"), \
+         patch.object(NetworkAnalyzerUI, "update_status"):
+        ui = NetworkAnalyzerUI(mock_tk_root)
+        with patch.object(ui.analyzer, "start_analysis", return_value=True):
+            ui.start_collection()
+        mock_scan.assert_called_once()


### PR DESCRIPTION
## Summary
- trigger Wi-Fi scanning when collection starts
- provide dummy UI widgets for tests
- verify that starting collection calls the scan function

## Testing
- `pytest -q`