### PR TITLE
Add Jest and TS unit tests

### DIFF
--- a/AuditWifiApp/README.md
+++ b/AuditWifiApp/README.md
@@ -217,6 +217,7 @@ Pour exécuter les tests, utilisez la commande suivante :
 
 ```bash
 pytest -v
+npm test
 ```
 
 Pour générer un rapport de couverture des tests :

--- a/AuditWifiApp/src/jest.config.js
+++ b/AuditWifiApp/src/jest.config.js
@@ -1,0 +1,9 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  roots: ['<rootDir>'],
+  testMatch: ['<rootDir>/tests/**/*.test.ts'],
+  moduleNameMapper: {
+    '^vscode$': '<rootDir>/tests/__mocks__/vscode.ts'
+  }
+};

--- a/AuditWifiApp/src/tests/__mocks__/vscode.ts
+++ b/AuditWifiApp/src/tests/__mocks__/vscode.ts
@@ -1,0 +1,13 @@
+export const window = {
+  showInformationMessage: jest.fn(),
+  showErrorMessage: jest.fn(),
+  showWarningMessage: jest.fn(),
+  withProgress: jest.fn((opts, task) => task({ report: () => {} })),
+};
+export const workspace = {
+  getConfiguration: jest.fn(() => ({ get: jest.fn() })),
+  fs: { writeFile: jest.fn(), readFile: jest.fn() },
+};
+export const ProgressLocation = { Notification: 0 };
+export const Uri = { file: jest.fn() } as any;
+export const commands = { executeCommand: jest.fn() };

--- a/AuditWifiApp/src/tests/configurationViewProvider.test.ts
+++ b/AuditWifiApp/src/tests/configurationViewProvider.test.ts
@@ -1,0 +1,9 @@
+import { ConfigurationViewProvider } from '../configurationViewProvider';
+
+/** Ensure default configuration contains expected keys. */
+test('returns default configuration', () => {
+  const provider = new ConfigurationViewProvider({} as any);
+  const cfg = provider.getCurrentConfig();
+  expect(cfg).toHaveProperty('min_transmission_rate');
+  expect(cfg).toHaveProperty('max_transmission_power');
+});

--- a/AuditWifiApp/src/tests/logsViewProvider.test.ts
+++ b/AuditWifiApp/src/tests/logsViewProvider.test.ts
@@ -1,0 +1,7 @@
+import { LogsViewProvider } from '../logsViewProvider';
+
+/** Simple test to ensure the provider can be instantiated. */
+test('creates LogsViewProvider without crashing', () => {
+  const provider = new LogsViewProvider({} as any);
+  expect(provider).toBeInstanceOf(LogsViewProvider);
+});

--- a/AuditWifiApp/src/tests/moxaAnalyzer.test.ts
+++ b/AuditWifiApp/src/tests/moxaAnalyzer.test.ts
@@ -1,0 +1,9 @@
+import MoxaAnalyzer from '../moxaAnalyzer';
+
+/** Instantiate MoxaAnalyzer with a dummy API key and verify utility method. */
+test('getUserFriendlyReport returns text', () => {
+  process.env.OPENAI_API_KEY = 'dummy';
+  const analyzer = new MoxaAnalyzer();
+  const report = analyzer.getUserFriendlyReport({ score: 10, max_score: 100 });
+  expect(typeof report).toBe('string');
+});

--- a/AuditWifiApp/tests/test_theme_config.py
+++ b/AuditWifiApp/tests/test_theme_config.py
@@ -1,15 +1,17 @@
 import yaml
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock
 from bootstrap_ui import BootstrapNetworkAnalyzerUI
 import app_config
 
 
 def test_bootstrap_ui_reads_theme_from_config(tmp_path):
+    """Verify the UI picks the theme value from the config file."""
     cfg = tmp_path / "config.yaml"
     cfg.write_text("interface:\n  theme: flatly\n")
     with patch("bootstrap_ui.load_config", return_value=yaml.safe_load(cfg.read_text())), \
          patch("bootstrap_ui.save_config") as save_cfg, \
-         patch("ttkbootstrap.Window") as win:
+         patch("ttkbootstrap.Window") as win, \
+         patch("tkinter.StringVar", return_value=MagicMock()):
         win.return_value.style.theme_names.return_value = ["flatly", "darkly"]
         ui = BootstrapNetworkAnalyzerUI()
         win.assert_called_with(themename="flatly")
@@ -17,13 +19,15 @@ def test_bootstrap_ui_reads_theme_from_config(tmp_path):
 
 
 def test_change_theme_updates_config(tmp_path):
+    """Ensure changing theme writes the new value to config."""
     cfg = tmp_path / "config.yaml"
     cfg.write_text("interface:\n  theme: darkly\n")
     store = yaml.safe_load(cfg.read_text())
 
     with patch("bootstrap_ui.load_config", return_value=store), \
          patch("bootstrap_ui.save_config") as save_cfg, \
-         patch("ttkbootstrap.Window") as win:
+         patch("ttkbootstrap.Window") as win, \
+         patch("tkinter.StringVar", return_value=MagicMock()):
         win.return_value.style.theme_names.return_value = ["darkly", "flatly"]
         ui = BootstrapNetworkAnalyzerUI()
         ui.change_theme("flatly")

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ roaming logic.
 
 ```bash
 pytest -v
+npm test # run TypeScript unit tests
 ```
 
 ## Repository layout


### PR DESCRIPTION
## Summary
- set up Jest config in `AuditWifiApp/src`
- add unit tests for the VS Code extension modules
- adjust Python tests for headless environments
- document running `npm test` in the READMEs

## Testing
- `pytest -q`