### PR TITLE
Refactor MoxaView layout

### DIFF
--- a/AuditWifiApp/ui/moxa_view.py
+++ b/AuditWifiApp/ui/moxa_view.py
@@ -47,15 +47,19 @@ class MoxaView:
     # Interface building
     # ------------------------------------------------------------------
     def create_interface(self) -> None:
-        """Create widgets for Moxa log analysis."""
-        paned = ttk.Panedwindow(self.frame, orient=tk.VERTICAL)
+        """Create widgets for Moxa log analysis using two columns."""
+        # Split the view horizontally: left column for logs/results, right column
+        # for configuration and actions. Panedwindow allows manual resizing.
+        paned = ttk.Panedwindow(self.frame, orient=tk.HORIZONTAL)
         paned.pack(fill=tk.BOTH, expand=True)
-        top_pane = ttk.Frame(paned)
-        bottom_pane = ttk.Frame(paned)
-        paned.add(top_pane, weight=1)
-        paned.add(bottom_pane, weight=1)
 
-        input_frame = ttk.LabelFrame(top_pane, text="Collez vos logs Moxa ici :", padding=10)
+        left_pane = ttk.Frame(paned)
+        right_pane = ttk.Frame(paned)
+        paned.add(left_pane, weight=3)
+        paned.add(right_pane, weight=2)
+
+        # ----- Left column: logs to analyze and resulting report -----
+        input_frame = ttk.LabelFrame(left_pane, text="Collez vos logs Moxa ici :", padding=10)
         input_frame.pack(fill=tk.BOTH, expand=True, padx=10, pady=5)
         self.moxa_input = tk.Text(input_frame, wrap=tk.WORD)
         input_scroll = ttk.Scrollbar(input_frame, command=self.moxa_input.yview)
@@ -63,7 +67,16 @@ class MoxaView:
         self.moxa_input.pack(side=tk.LEFT, fill=tk.BOTH, expand=True)
         input_scroll.pack(side=tk.RIGHT, fill=tk.Y)
 
-        cfg_frame = ttk.LabelFrame(top_pane, text="Configuration Moxa actuelle (JSON) :", padding=10)
+        results_frame = ttk.LabelFrame(left_pane, text="R\u00e9sultats de l'analyse :", padding=10)
+        results_frame.pack(fill=tk.BOTH, expand=True, padx=10, pady=5)
+        self.moxa_results = tk.Text(results_frame, wrap=tk.WORD)
+        res_scroll = ttk.Scrollbar(results_frame, command=self.moxa_results.yview)
+        self.moxa_results.configure(yscrollcommand=res_scroll.set)
+        self.moxa_results.pack(side=tk.LEFT, fill=tk.BOTH, expand=True)
+        res_scroll.pack(side=tk.RIGHT, fill=tk.Y)
+
+        # ----- Right column: configuration, parameters and action buttons -----
+        cfg_frame = ttk.LabelFrame(right_pane, text="Configuration Moxa actuelle (JSON) :", padding=10)
         cfg_frame.pack(fill=tk.BOTH, expand=True, padx=10, pady=5)
         self.moxa_config_text = tk.Text(cfg_frame, height=8, wrap=tk.WORD)
         cfg_scroll = ttk.Scrollbar(cfg_frame, command=self.moxa_config_text.yview)
@@ -72,7 +85,7 @@ class MoxaView:
         cfg_scroll.pack(side=tk.RIGHT, fill=tk.Y)
         self.moxa_config_text.insert('1.0', json.dumps(self.current_config, indent=2))
 
-        params_frame = ttk.LabelFrame(top_pane, text="Param\u00e8tres suppl\u00e9mentaires :", padding=10)
+        params_frame = ttk.LabelFrame(right_pane, text="Param\u00e8tres suppl\u00e9mentaires :", padding=10)
         params_frame.pack(fill=tk.BOTH, expand=True, padx=10, pady=5)
         self.moxa_params_text = tk.Text(params_frame, height=4, wrap=tk.WORD)
         params_scroll = ttk.Scrollbar(params_frame, command=self.moxa_params_text.yview)
@@ -81,23 +94,15 @@ class MoxaView:
         params_scroll.pack(side=tk.RIGHT, fill=tk.Y)
         ttk.Label(params_frame, text="Indiquez ici tout contexte suppl\u00e9mentaire (ex. roaming=snr)").pack(anchor=tk.W, pady=(5, 0))
 
-        cfg_btn_frame = ttk.Frame(top_pane)
+        cfg_btn_frame = ttk.Frame(right_pane)
         cfg_btn_frame.pack(pady=5)
         ttk.Button(cfg_btn_frame, text="Charger config", command=self.load_config).pack(side=tk.LEFT, padx=5)
         ttk.Button(cfg_btn_frame, text="\xc9diter config", command=self.edit_config).pack(side=tk.LEFT, padx=5)
 
-        self.analyze_button = ttk.Button(top_pane, text="\U0001F50E Analyser les logs", command=self.analyze_moxa_logs)
+        self.analyze_button = ttk.Button(right_pane, text="\U0001F50E Analyser les logs", command=self.analyze_moxa_logs)
         self.analyze_button.pack(pady=10)
 
-        results_frame = ttk.LabelFrame(bottom_pane, text="R\u00e9sultats de l'analyse :", padding=10)
-        results_frame.pack(fill=tk.BOTH, expand=True, padx=10, pady=5)
-        self.moxa_results = tk.Text(results_frame, wrap=tk.WORD)
-        res_scroll = ttk.Scrollbar(results_frame, command=self.moxa_results.yview)
-        self.moxa_results.configure(yscrollcommand=res_scroll.set)
-        self.moxa_results.pack(side=tk.LEFT, fill=tk.BOTH, expand=True)
-        res_scroll.pack(side=tk.RIGHT, fill=tk.Y)
-
-        self.export_button = ttk.Button(bottom_pane, text="\U0001F4BE Exporter l'analyse", command=self.export_data, state=tk.DISABLED)
+        self.export_button = ttk.Button(right_pane, text="\U0001F4BE Exporter l'analyse", command=self.export_data, state=tk.DISABLED)
         self.export_button.pack(pady=5)
 
     # ------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- restructure `create_interface` in MoxaView to use a horizontal split
- keep logs and results on the left and configuration/actions on the right

## Testing
- `pytest -v` *(fails: test_theme_config::test_custom_theme_loaded_from_config)*