### PR TITLE
Update README instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,12 @@ AuditWifiApp is a Python application for auditing Wi-Fi coverage in factories. I
    `.env` is ignored by Git so your key stays local.
 4. Launch the user interface:
    ```bash
-   python AuditWifiApp/runner.py
+   python AuditWifiApp/main.py
+   ```
+5. If you use the bundled VS Code extension, build the TypeScript files first:
+   ```bash
+   npm install
+   npm run compile
    ```
 
 ## Configuration
@@ -44,6 +49,11 @@ wifi_thresholds:
 ```
 
 ## Usage
+
+Start the application with:
+```bash
+python AuditWifiApp/main.py
+```
 
 When analyzing Moxa logs, paste them in the dedicated tab. Optionally fill in
 the **Paramètres supplémentaires** field to give extra context to the AI. For


### PR DESCRIPTION
## Summary
- launch `python AuditWifiApp/main.py` from Setup and Usage sections
- mention TypeScript build step for the VS Code extension

## Testing
- `pytest -v` *(fails: test_moxa_view, test_wifi_view)*