### PR TITLE
Update WiFi view data retrieval

### DIFF
--- a/AuditWifiApp/ui/wifi_view.py
+++ b/AuditWifiApp/ui/wifi_view.py
@@ -427,11 +427,12 @@ class WifiView:
     def _update_data(self) -> None:
         """Update displayed data."""
         try:
-            # Get latest sample
+            # Get latest sample via collector helper
             collector = getattr(self.analyzer, 'wifi_collector', None)
             if collector:
-                sample = getattr(collector, 'last_sample', None)
-                if sample:
+                # Use dedicated accessor to fetch the latest collected sample
+                sample = collector.get_latest_sample()
+                if sample is not None:
                     self.samples.append(sample)
                     if len(self.samples) > self.max_samples:
                         self.samples.pop(0)


### PR DESCRIPTION
## Summary
- use the collector `get_latest_sample` accessor in WifiView

## Testing
- `pytest -v` *(fails: AttributeError: <class 'runner.NetworkAnalyzerUI'> does not have the attribute 'setup_graphs')*