### PR TITLE
Improve Moxa configuration editor

### DIFF
--- a/AuditWifiApp/tests/conftest.py
+++ b/AuditWifiApp/tests/conftest.py
@@ -134,6 +134,9 @@ def patch_ttk_style():
         def pack(self, *args, **kwargs):
             pass
 
+        def grid(self, *args, **kwargs):
+            pass
+
         def config(self, **kwargs):
             self.options.update(kwargs)
 
@@ -168,6 +171,7 @@ def patch_ttk_style():
         patch('tkinter.Text'),
 
         patch('tkinter.StringVar', DummyStringVar),
+        patch('tkinter.BooleanVar', DummyStringVar),
 
         patch('tkinter.ttk.Treeview', DummyTreeview),
         patch('tkinter.ttk.Button', DummyButton),

--- a/AuditWifiApp/tests/test_moxa_view.py
+++ b/AuditWifiApp/tests/test_moxa_view.py
@@ -1,6 +1,8 @@
 import os
 import tkinter as tk
 import importlib
+from unittest.mock import patch
+
 from ui import moxa_view as moxa_view_module
 
 
@@ -18,3 +20,16 @@ def test_show_metrics_help_displays_message(mock_tk_root, tmp_path):
     view = module.MoxaView(mock_tk_root, str(tmp_path), {})
     view.show_metrics_help()
     module.messagebox.showinfo.assert_called_once()
+
+
+def test_edit_config_uses_checkbutton_for_bool(mock_tk_root, tmp_path):
+    """Boolean fields should render as checkboxes in the edit dialog."""
+    module = importlib.reload(moxa_view_module)
+    view = module.MoxaView(mock_tk_root, str(tmp_path), {"enabled": True, "power": 5})
+
+    with patch.object(module.ttk, "Checkbutton") as check_mock, \
+         patch.object(module.tk, "Toplevel"):
+        view.edit_config()
+
+    # Only one boolean field should generate one Checkbutton
+    assert check_mock.call_count == 1


### PR DESCRIPTION
## Summary
- add checkbox handling and reset button in `MoxaView.edit_config`
- patch dummy GUI widgets to support grid layout
- test that boolean options create checkboxes

## Testing
- `pytest -v`