### PR TITLE
Fix duplicate helper functions

### DIFF
--- a/AuditWifiApp/ui/moxa_view.py
+++ b/AuditWifiApp/ui/moxa_view.py
@@ -402,22 +402,3 @@ class MoxaView:
             messagebox.showerror("Erreur", f"Impossible d'exporter les donn\u00e9es : {exc}")
 
 
-    def load_example_log(self) -> None:
-        """Insert the bundled example log into the input widget."""
-        try:
-            with open(self.example_log_path, "r", encoding="utf-8") as f:
-                sample = f.read()
-            self.moxa_input.delete("1.0", tk.END)
-            self.moxa_input.insert("1.0", sample)
-        except Exception as exc:  # pragma: no cover - any failure just warns
-            messagebox.showerror("Erreur", f"Impossible de charger l'exemple : {exc}")
-
-    def show_metrics_help(self) -> None:
-        """Display a short description of the metrics used for analysis."""
-        text = (
-            "Les principales métriques analysées sont :\n"
-            "- Handoff time (temps de bascule entre AP).\n"
-            "- Taux de déauthentifications.\n"
-            "- Niveau de SNR et de RSSI."
-        )
-        messagebox.showinfo("Aide", text)


### PR DESCRIPTION
## Summary
- remove duplicate definitions of `load_example_log` and `show_metrics_help`

## Testing
- `pytest -v`
