### PR TITLE
Update MoxaView params textarea

### DIFF
--- a/AuditWifiApp/tests/test_moxa_view.py
+++ b/AuditWifiApp/tests/test_moxa_view.py
@@ -33,3 +33,15 @@ def test_edit_config_uses_checkbutton_for_bool(mock_tk_root, tmp_path):
 
     # Only one boolean field should generate one Checkbutton
     assert check_mock.call_count == 1
+
+
+def test_params_field_height_and_label(mock_tk_root, tmp_path):
+    """The params text widget should be taller and label without example."""
+    with patch("tkinter.Text") as text_mock, patch("tkinter.ttk.Label") as label_mock:
+        module = importlib.reload(moxa_view_module)
+        module.MoxaView(mock_tk_root, str(tmp_path), {})
+
+    assert text_mock.call_args_list[3].kwargs.get("height") == 8
+    texts = [c.kwargs.get("text") for c in label_mock.call_args_list]
+    assert "Indiquez ici tout contexte supplémentaire" in texts
+    assert all("roaming" not in t for t in texts if t)

--- a/AuditWifiApp/ui/moxa_view.py
+++ b/AuditWifiApp/ui/moxa_view.py
@@ -106,12 +106,17 @@ class MoxaView:
         params_frame.pack(fill=tk.BOTH, expand=True, padx=10, pady=5)
         help_btn = ttk.Button(params_frame, text="\u2753", width=3, command=self.show_metrics_help)
         help_btn.pack(side=tk.RIGHT, padx=5)
-        self.moxa_params_text = tk.Text(params_frame, height=4, wrap=tk.WORD)
+        # Additional parameters from the user
+        self.moxa_params_text = tk.Text(params_frame, height=8, wrap=tk.WORD)
         params_scroll = ttk.Scrollbar(params_frame, command=self.moxa_params_text.yview)
         self.moxa_params_text.configure(yscrollcommand=params_scroll.set)
         self.moxa_params_text.pack(side=tk.LEFT, fill=tk.BOTH, expand=True)
         params_scroll.pack(side=tk.RIGHT, fill=tk.Y)
-        ttk.Label(params_frame, text="Indiquez ici tout contexte suppl\u00e9mentaire (ex. roaming=snr)").pack(anchor=tk.W, pady=(5, 0))
+        # Hint label for the parameters field
+        ttk.Label(
+            params_frame,
+            text="Indiquez ici tout contexte supplémentaire",
+        ).pack(anchor=tk.W, pady=(5, 0))
 
         cfg_btn_frame = ttk.Frame(right_pane)
         cfg_btn_frame.pack(pady=5)


### PR DESCRIPTION
## Summary
- enlarge the parameters textarea in `MoxaView`
- remove the roaming example from the helper label
- verify new UI changes with unit tests

## Testing
- `pytest -v`