### PR TITLE
Add background scanning thread

### DIFF
--- a/AuditWifiApp/tests/conftest.py
+++ b/AuditWifiApp/tests/conftest.py
@@ -186,6 +186,7 @@ def patch_ttk_style():
         patch('tkinter.ttk.Button', DummyButton),
         patch('tkinter.ttk.OptionMenu'),
         patch('tkinter.Menu'),
+        patch('tkinter.Misc.after', lambda self, ms, func=None: func() if func else None),
         patch('matplotlib.backends.backend_tkagg.FigureCanvasTkAgg'),
         patch('runner.NetworkAnalyzerUI.setup_graphs', lambda self: None),
     ]

--- a/AuditWifiApp/tests/test_network_scan_ui.py
+++ b/AuditWifiApp/tests/test_network_scan_ui.py
@@ -27,7 +27,21 @@ def test_scan_wifi_populates_tree(mock_tk_root):
         {"ssid": "AP1", "signal": -40, "channel": 1, "frequency": "2.4 GHz"},
         {"ssid": "AP2", "signal": -50, "channel": 36, "frequency": "5 GHz"},
     ]
-    with patch("runner.scan_wifi", return_value=mock_results) as mock_scan:
+    with (
+        patch("runner.scan_wifi", return_value=mock_results) as mock_scan,
+        patch("ui.wifi_view.threading.Thread") as mock_thread,
+    ):
+        def make_thread(*args, **kwargs):
+            target = kwargs.get("target")
+            if target is None and args:
+                target = args[0]
+            class DummyThread:
+                def __init__(self, target):
+                    self.target = target
+                def start(self):
+                    self.target()
+            return DummyThread(target)
+        mock_thread.side_effect = make_thread
         ui = WifiView(mock_tk_root, DummyAnalyzer())
         ui.scan_nearby_aps()
         mock_scan.assert_called_once()
@@ -42,7 +56,21 @@ def test_export_scan_results(tmp_path, mock_tk_root):
     mock_results = [
         {"ssid": "AP1", "signal": -40, "channel": 1, "frequency": "2.4 GHz"}
     ]
-    with patch("runner.scan_wifi", return_value=mock_results):
+    with (
+        patch("runner.scan_wifi", return_value=mock_results),
+        patch("ui.wifi_view.threading.Thread") as mock_thread,
+    ):
+        def make_thread(*args, **kwargs):
+            target = kwargs.get("target")
+            if target is None and args:
+                target = args[0]
+            class DummyThread:
+                def __init__(self, target):
+                    self.target = target
+                def start(self):
+                    self.target()
+            return DummyThread(target)
+        mock_thread.side_effect = make_thread
         ui = WifiView(mock_tk_root, DummyAnalyzer())
         ui.scan_nearby_aps()
     export_file = tmp_path / "scan.csv"
@@ -56,9 +84,23 @@ def test_export_scan_results(tmp_path, mock_tk_root):
 
 
 def test_start_collection_triggers_scan(mock_tk_root):
-    with patch("runner.scan_wifi") as mock_scan, \
-         patch.object(WifiView, "update_data"), \
-         patch.object(WifiView, "update_status"):
+    with (
+        patch("runner.scan_wifi") as mock_scan,
+        patch.object(WifiView, "update_data"),
+        patch.object(WifiView, "update_status"),
+        patch("ui.wifi_view.threading.Thread") as mock_thread,
+    ):
+        def make_thread(*args, **kwargs):
+            target = kwargs.get("target")
+            if target is None and args:
+                target = args[0]
+            class DummyThread:
+                def __init__(self, target):
+                    self.target = target
+                def start(self):
+                    self.target()
+            return DummyThread(target)
+        mock_thread.side_effect = make_thread
         ui = WifiView(mock_tk_root, DummyAnalyzer())
         with patch.object(ui.analyzer, "start_analysis", return_value=True):
             ui.start_collection()
@@ -72,7 +114,21 @@ def test_filter_and_sorting(mock_tk_root):
         {"ssid": "AP2", "signal": -40, "channel": 6, "frequency": "2.4 GHz"},
         {"ssid": "Guest", "signal": -60, "channel": 11, "frequency": "2.4 GHz"},
     ]
-    with patch("runner.scan_wifi", return_value=mock_results):
+    with (
+        patch("runner.scan_wifi", return_value=mock_results),
+        patch("ui.wifi_view.threading.Thread") as mock_thread,
+    ):
+        def make_thread(*args, **kwargs):
+            target = kwargs.get("target")
+            if target is None and args:
+                target = args[0]
+            class DummyThread:
+                def __init__(self, target):
+                    self.target = target
+                def start(self):
+                    self.target()
+            return DummyThread(target)
+        mock_thread.side_effect = make_thread
         ui = WifiView(mock_tk_root, DummyAnalyzer())
         ui.scan_nearby_aps()
 
@@ -88,3 +144,23 @@ def test_filter_and_sorting(mock_tk_root):
     items = ui.scan_tree.get_children()
     assert len(items) == 2
     assert ui.scan_tree.item(items[0])["values"][0] == "AP2"
+
+
+def test_scan_runs_in_background(mock_tk_root):
+    """Scanning should not block the UI thread."""
+    mock_result = [{"ssid": "AP1", "signal": -40, "channel": 1, "frequency": "2.4 GHz"}]
+
+    def delayed_scan():
+        import time
+        time.sleep(0.1)
+        return mock_result
+
+    with patch("runner.scan_wifi", side_effect=delayed_scan):
+        ui = WifiView(mock_tk_root, DummyAnalyzer())
+        start = __import__("time").perf_counter()
+        ui.scan_nearby_aps()
+        elapsed = __import__("time").perf_counter() - start
+        assert elapsed < 0.05
+        ui._scan_thread.join()
+        items = ui.scan_tree.get_children()
+        assert len(items) == 1


### PR DESCRIPTION
## Summary
- run wifi scans in a background thread and update UI via `after`
- patch tests to handle threading
- ensure widgets process callbacks immediately in tests
- add unit test confirming UI stays responsive during scanning

## Testing
- `pytest -v`