### PR TITLE
Extend WiFi stats display

### DIFF
--- a/AuditWifiApp/runner.py
+++ b/AuditWifiApp/runner.py
@@ -120,7 +120,10 @@ class NetworkAnalyzerUI:
         stats_frame = ttk.LabelFrame(control_frame, text="Statistiques", padding=5)
         stats_frame.pack(fill=tk.X, pady=10)
 
-        self.stats_text = tk.Text(stats_frame, height=6, width=30)
+        # Agrandir l'affichage des statistiques pour eviter de devoir defiler
+        # afin de lire toutes les informations. Une hauteur plus grande permet
+        # de voir la plupart des lignes en un coup d'oeil.
+        self.stats_text = tk.Text(stats_frame, height=10, width=40)
         self.stats_text.pack(fill=tk.X, pady=5)
 
         # Panneau des graphiques et alertes (droite)


### PR DESCRIPTION
## Summary
- widen the statistics view so that all metrics show without scrolling

## Testing
- `pytest -q`