### PR TITLE
Add custom instructions for Moxa analysis

### DIFF
--- a/AuditWifiApp/moxa_analyzer.py
+++ b/AuditWifiApp/moxa_analyzer.py
@@ -14,7 +14,7 @@ class MoxaLogAnalyzer:
     def __init__(self):
         self.api_key = os.getenv("OPENAI_API_KEY")
 
-    def analyze_logs(self, log_content, current_config):
+    def analyze_logs(self, log_content, current_config, custom_instructions: str | None = None):
         """
         Analyse les logs Moxa via l'API OpenAI pour identifier les problèmes
         et générer des recommandations d'optimisation.
@@ -22,6 +22,7 @@ class MoxaLogAnalyzer:
         Args:
             log_content (str): Contenu des logs à analyser
             current_config (dict): Configuration Moxa actuelle
+            custom_instructions (str | None): Instructions additionnelles pour personnaliser l'analyse
             
         Returns:
             dict: Résultat de l'analyse contenant les problèmes détectés
@@ -41,6 +42,7 @@ class MoxaLogAnalyzer:
         clean_logs = log_content.replace("\r\n", "\n").strip()
 
         # Créer le prompt pour l'analyse
+        extra = f"\nInstructions supplémentaires :\n{custom_instructions}" if custom_instructions else ""
         prompt = (
             "En tant qu'expert Wi-Fi industriel, analyser ces logs en détail en recherchant spécifiquement:\n"
             "1. Effet 'ping-pong' : roaming rapide et répété entre les mêmes points d'accès\n"
@@ -139,7 +141,7 @@ class MoxaLogAnalyzer:
             "    ]\n"
             "  }\n"
             "}\n\n"
-            f"LOGS À ANALYSER:\n{clean_logs}"
+            f"LOGS À ANALYSER:\n{clean_logs}" + extra
         )
 
         try:

--- a/AuditWifiApp/src/extension.ts
+++ b/AuditWifiApp/src/extension.ts
@@ -32,7 +32,7 @@ export function activate(context: vscode.ExtensionContext) {
     );
 
     // Commande pour analyser les logs
-    const analyzeCommand = vscode.commands.registerCommand('moxa-wifi-analyzer.analyze', async () => {
+    const analyzeCommand = vscode.commands.registerCommand('moxa-wifi-analyzer.analyze', async (customInstructions?: string) => {
         try {
             // Demander à l'utilisateur de sélectionner un fichier log
             const logFiles = await vscode.window.showOpenDialog({
@@ -70,7 +70,7 @@ export function activate(context: vscode.ExtensionContext) {
                 try {
                     progress.report({ increment: 30, message: "Traitement des logs..." });
                     
-                    analysisResults = await moxaAnalyzer.analyzeLog(logContent, config);
+                    analysisResults = await moxaAnalyzer.analyzeLog(logContent, config, customInstructions || '');
                     
                     progress.report({ increment: 70, message: "Génération des recommandations..." });
 

--- a/AuditWifiApp/src/moxaAnalyzer.ts
+++ b/AuditWifiApp/src/moxaAnalyzer.ts
@@ -55,7 +55,7 @@ export default class MoxaAnalyzer {
      * @param currentConfig - Configuration actuelle du Moxa
      * @returns Résultats de l'analyse
      */
-    public async analyzeLog(logContent: string, currentConfig: any): Promise<any> {
+    public async analyzeLog(logContent: string, currentConfig: any, customInstructions: string = ''): Promise<any> {
         if (!this.apiKey) {
             // Si pas de clé API, demander à l'utilisateur
             const apiKey = await vscode.window.showInputBox({
@@ -82,7 +82,7 @@ export default class MoxaAnalyzer {
         }
         
         // Créer le prompt pour l'IA
-        const prompt = this._createAnalysisPrompt(truncatedLog, currentConfig);
+        const prompt = this._createAnalysisPrompt(truncatedLog, currentConfig, customInstructions);
         
         // Appeler l'API IA
         const aiResponse = await this._callAiApi(prompt);
@@ -101,12 +101,13 @@ export default class MoxaAnalyzer {
      * @param currentConfig - Configuration actuelle du Moxa
      * @returns Prompt pour l'API IA
      */
-    private _createAnalysisPrompt(logContent: string, currentConfig: any): string {
+    private _createAnalysisPrompt(logContent: string, currentConfig: any, customInstructions: string): string {
         // Convertir la configuration actuelle en texte formaté
         const configText = JSON.stringify(currentConfig, null, 2);
         
         // Créer le prompt avec instructions spécifiques pour l'IA
-        return `En tant qu'expert en réseaux sans fil et particulièrement en configuration d'appareils Moxa, analysez le log suivant et la configuration actuelle pour fournir des recommandations d'optimisation du roaming.
+        const extra = customInstructions && customInstructions.trim() ? `\n\nInstructions supplémentaires :\n${customInstructions}` : '';
+        return `En tant qu'expert en réseaux sans fil et particulièrement en configuration d'appareils Moxa, analysez le log suivant et la configuration actuelle pour fournir des recommandations d'optimisation du roaming.${extra}
 
 ## Configuration actuelle du Moxa:
 \`\`\`json

--- a/AuditWifiApp/src/moxaAnalyzerStandalone.ts
+++ b/AuditWifiApp/src/moxaAnalyzerStandalone.ts
@@ -37,7 +37,7 @@ class MoxaAnalyzerStandalone {
         };
     }
 
-    public async analyzeLog(logContent: string, currentConfig: any): Promise<any> {
+    public async analyzeLog(logContent: string, currentConfig: any, customInstructions: string = ''): Promise<any> {
         console.log("Analyse du log avec l'IA en cours...");
         
         const max_log_length = 15000;
@@ -47,7 +47,7 @@ class MoxaAnalyzerStandalone {
             console.log(`Log tronqué de ${logContent.length} à ${max_log_length} caractères pour l'analyse IA.`);
         }
         
-        const prompt = this._createAnalysisPrompt(truncatedLog, currentConfig);
+        const prompt = this._createAnalysisPrompt(truncatedLog, currentConfig, customInstructions);
         const aiResponse = await this._callAiApi(prompt);
         
         if (!aiResponse) {
@@ -57,9 +57,10 @@ class MoxaAnalyzerStandalone {
         return this._processAiResponse(aiResponse, currentConfig);
     }
 
-    private _createAnalysisPrompt(logContent: string, currentConfig: any): string {
+    private _createAnalysisPrompt(logContent: string, currentConfig: any, customInstructions: string): string {
         const configText = JSON.stringify(currentConfig, null, 2);
-        return `En tant qu'expert en réseaux sans fil et particulièrement en configuration d'appareils Moxa, analysez le log suivant et la configuration actuelle pour fournir des recommandations d'optimisation du roaming.
+        const extra = customInstructions && customInstructions.trim() ? `\n\nInstructions supplémentaires :\n${customInstructions}` : '';
+        return `En tant qu'expert en réseaux sans fil et particulièrement en configuration d'appareils Moxa, analysez le log suivant et la configuration actuelle pour fournir des recommandations d'optimisation du roaming.${extra}
 
 ## Configuration actuelle du Moxa:
 \`\`\`json


### PR DESCRIPTION
## Summary
- allow passing custom instructions from the logs view
- forward instructions through extension command to analyzers
- include optional instructions when building OpenAI prompts

## Testing
- `pytest -q`