### PR TITLE
Add MAC address tagging feature

### DIFF
--- a/AuditWifiApp/mac_tag_manager.py
+++ b/AuditWifiApp/mac_tag_manager.py
@@ -1,0 +1,62 @@
+import json
+import os
+import re
+import shutil
+from typing import Dict, Optional
+
+MAC_FILE = "mac_tags.json"
+BACKUP_FILE = "mac_tags_backup.json"
+
+class MacTagManager:
+    """Manage MAC address tags and persistence."""
+
+    def __init__(self, file_path: str = MAC_FILE):
+        self.file_path = file_path
+        self.backup_file = BACKUP_FILE
+        self.tags: Dict[str, str] = {}
+        self.load_tags()
+
+    def load_tags(self) -> None:
+        """Load tags from disk, creating an empty file if needed."""
+        if not os.path.exists(self.file_path):
+            self.tags = {}
+            return
+        try:
+            with open(self.file_path, "r", encoding="utf-8") as f:
+                self.tags = json.load(f)
+        except Exception:
+            self.tags = {}
+            try:
+                shutil.copy(self.file_path, self.backup_file)
+            except Exception:
+                pass
+
+    def save_tags(self) -> None:
+        """Save tags to disk and create a backup."""
+        try:
+            if os.path.exists(self.file_path):
+                shutil.copy(self.file_path, self.backup_file)
+            with open(self.file_path, "w", encoding="utf-8") as f:
+                json.dump(self.tags, f, indent=2)
+        except Exception as e:
+            print(f"Failed to save MAC tags: {e}")
+
+    @staticmethod
+    def validate_mac(mac: str) -> bool:
+        """Validate MAC address format (AA:BB:CC:DD:EE:FF)."""
+        return bool(re.fullmatch(r"([0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2}", mac))
+
+    def get_tag(self, mac: str) -> Optional[str]:
+        """Return tag associated with MAC if any."""
+        return self.tags.get(mac.upper())
+
+    def set_tag(self, mac: str, tag: str) -> bool:
+        """Add or update tag for MAC address. Returns True on success."""
+        if not self.validate_mac(mac):
+            return False
+        self.tags[mac.upper()] = tag.strip()
+        return True
+
+    def delete_tag(self, mac: str) -> None:
+        """Remove tag for MAC address."""
+        self.tags.pop(mac.upper(), None)

--- a/AuditWifiApp/runner.py
+++ b/AuditWifiApp/runner.py
@@ -4,7 +4,7 @@ import json
 import logging
 from datetime import datetime
 import tkinter as tk
-from tkinter import ttk, messagebox, filedialog
+from tkinter import ttk, messagebox, filedialog, simpledialog
 
 # Configuration sécurisée de Matplotlib avant les imports
 import matplotlib
@@ -30,6 +30,7 @@ from amr_monitor import AMRMonitor
 from wifi.wifi_collector import WifiSample
 from src.ai.simple_moxa_analyzer import analyze_moxa_logs
 from config_manager import ConfigurationManager
+from mac_tag_manager import MacTagManager
 
 class NetworkAnalyzerUI:
     def __init__(self, master: tk.Tk):
@@ -80,6 +81,9 @@ class NetworkAnalyzerUI:
             except Exception:
                 pass
         self.current_config = self.config_manager.get_config()
+
+        # Manager for MAC address tags
+        self.mac_manager = MacTagManager()
 
         # Configuration du style
         self.setup_style()
@@ -223,7 +227,18 @@ class NetworkAnalyzerUI:
             command=self.stop_collection,
             state=tk.DISABLED
         )
-        self.stop_button.pack(fill=tk.X, pady=5)        # Zone de statistiques - Compacte
+        self.stop_button.pack(fill=tk.X, pady=5)
+
+        # Button to manage MAC address tags
+        self.mac_manage_button = ttk.Button(
+            control_frame,
+            text="🗂 Gérer les MAC",
+            command=self.open_mac_tag_manager
+        )
+        self.mac_manage_button.pack(fill=tk.X, pady=5)
+
+        # Zone de statistiques - Compacte
+        stats_frame = ttk.LabelFrame(control_frame, text="Statistiques", padding=5)
         stats_frame = ttk.LabelFrame(control_frame, text="Statistiques", padding=5)
         stats_frame.pack(fill=tk.X, pady=(5, 5))
 
@@ -800,6 +815,9 @@ class NetworkAnalyzerUI:
         sample = self.analyzer.wifi_collector.collect_sample()
         if sample:
             self.samples.append(sample)
+            # Prompt for tag if new access point detected
+            if sample.bssid and not self.mac_manager.get_tag(sample.bssid):
+                self.prompt_for_tag(sample.bssid)
             self.update_display()
             self.update_stats()
             self.check_wifi_issues(sample)
@@ -895,7 +913,9 @@ class NetworkAnalyzerUI:
 
                 # Ajouter le BSSID si disponible
                 if entry.get('bssid') and entry['bssid'] != "Unknown":
-                    history_text += f", AP: {entry['bssid']}"
+                    tag = self.mac_manager.get_tag(entry['bssid'])
+                    tag_str = f" ({tag})" if tag else ""
+                    history_text += f", AP: {entry['bssid']}{tag_str}"
 
                 history_text += "\n"
 
@@ -1266,6 +1286,67 @@ class NetworkAnalyzerUI:
                 lines.append(f"{ip} : ❌")
         self.amr_status_text.delete("1.0", tk.END)
         self.amr_status_text.insert("1.0", "\n".join(lines))
+
+    def open_mac_tag_manager(self) -> None:
+        """Open a window to manage MAC address tags."""
+        window = tk.Toplevel(self.master)
+        window.title("Gestion des MAC")
+        window.geometry("400x300")
+
+        search_var = tk.StringVar()
+        ttk.Entry(window, textvariable=search_var).pack(fill=tk.X, padx=5, pady=5)
+
+        tree = ttk.Treeview(window, columns=("mac", "tag"), show="headings")
+        tree.heading("mac", text="MAC")
+        tree.heading("tag", text="Tag")
+        tree.pack(fill=tk.BOTH, expand=True, padx=5, pady=5)
+
+        def populate():
+            tree.delete(*tree.get_children())
+            query = search_var.get().lower()
+            for mac, tag in sorted(self.mac_manager.tags.items()):
+                if query in mac.lower() or query in tag.lower():
+                    tree.insert("", tk.END, values=(mac, tag))
+
+        populate()
+
+        def add_or_edit():
+            mac = simpledialog.askstring("Adresse MAC", "MAC:")
+            if not mac:
+                return
+            if not self.mac_manager.validate_mac(mac):
+                messagebox.showerror("MAC invalide", "Format MAC invalide")
+                return
+            tag = simpledialog.askstring("Tag", "Tag:") or ""
+            self.mac_manager.set_tag(mac, tag)
+            self.mac_manager.save_tags()
+            populate()
+
+        def delete_selected():
+            item = tree.selection()
+            if not item:
+                return
+            mac = tree.item(item[0], "values")[0]
+            self.mac_manager.delete_tag(mac)
+            self.mac_manager.save_tags()
+            populate()
+
+        btn_frame = ttk.Frame(window)
+        btn_frame.pack(fill=tk.X, pady=5)
+        ttk.Button(btn_frame, text="Ajouter/Éditer", command=add_or_edit).pack(side=tk.LEFT, padx=5)
+        ttk.Button(btn_frame, text="Supprimer", command=delete_selected).pack(side=tk.LEFT, padx=5)
+        ttk.Button(btn_frame, text="Fermer", command=window.destroy).pack(side=tk.RIGHT, padx=5)
+
+        search_var.trace_add("write", lambda *args: populate())
+
+    def prompt_for_tag(self, mac: str) -> None:
+        """Prompt user to tag a newly seen MAC address."""
+        if not self.mac_manager.validate_mac(mac):
+            return
+        tag = simpledialog.askstring("Nouveau point d'accès", f"Tag pour {mac} :")
+        if tag is not None:
+            self.mac_manager.set_tag(mac, tag)
+            self.mac_manager.save_tags()
 
     # === MÉTHODES DE NAVIGATION TEMPORELLE ===
 
@@ -1791,7 +1872,9 @@ class NetworkAnalyzerUI:
                     avg_quality = sum(info['qualities']) / len(info['qualities'])
                     alert_rate = (info['alerts'] / info['count'] * 100) if info['count'] > 0 else 0
 
-                    stats_text += f"\n  🔸 {bssid}\n"
+                    tag = self.mac_manager.get_tag(bssid)
+                    tag_str = f" ({tag})" if tag else ""
+                    stats_text += f"\n  🔸 {bssid}{tag_str}\n"
                     stats_text += f"    • Échantillons : {info['count']}\n"
                     stats_text += f"    • Signal moyen : {avg_signal:.1f} dBm\n"
                     stats_text += f"    • Qualité moyenne : {avg_quality:.1f}%\n"

--- a/AuditWifiApp/tests/test_mac_tag_manager.py
+++ b/AuditWifiApp/tests/test_mac_tag_manager.py
@@ -1,0 +1,19 @@
+import tkinter.messagebox  # ensure attribute for patched fixture
+from mac_tag_manager import MacTagManager
+
+
+def test_validate_mac():
+    manager = MacTagManager()
+    assert manager.validate_mac("AA:BB:CC:DD:EE:FF")
+    assert not manager.validate_mac("ZZ:BB:CC:DD:EE:FF")
+    assert not manager.validate_mac("AABBCCDDEEFF")
+
+
+def test_add_and_get_tag(tmp_path, monkeypatch):
+    temp_file = tmp_path / "tags.json"
+    manager = MacTagManager(file_path=str(temp_file))
+    manager.set_tag("AA:BB:CC:DD:EE:FF", "Warehouse")
+    manager.save_tags()
+
+    new_manager = MacTagManager(file_path=str(temp_file))
+    assert new_manager.get_tag("AA:BB:CC:DD:EE:FF") == "Warehouse"


### PR DESCRIPTION
## Summary
- add `MacTagManager` for tagging WiFi access points
- manage MAC tags from the UI with a dedicated button
- prompt user to tag unrecognized access points
- show tags alongside MAC addresses in stats and history
- test `MacTagManager`

## Testing
- `pytest AuditWifiApp/tests/test_mac_tag_manager.py -q`
- `pytest AuditWifiApp/tests/test_mac_tag_manager.py AuditWifiApp/tests/test_wifi_collector_v2.py -q`
