### PR TITLE
Add MAC tag manager UI and AMR monitoring controls

### DIFF
--- a/AuditWifiApp/mac_tag_manager.py
+++ b/AuditWifiApp/mac_tag_manager.py
@@ -57,6 +57,13 @@ class MacTagManager:
         self.tags[mac.upper()] = tag.strip()
         return True
 
+    def add_tag(self, mac: str, tag: str) -> bool:
+        """Convenience wrapper that sets a tag and immediately saves."""
+        if self.set_tag(mac, tag):
+            self.save_tags()
+            return True
+        return False
+
     def delete_tag(self, mac: str) -> None:
         """Remove tag for MAC address."""
         self.tags.pop(mac.upper(), None)


### PR DESCRIPTION
## Summary
- expand `MacTagManager` with `add_tag` helper that saves immediately
- add AMR monitoring start/stop functionality and status updates
- implement simple UI to manage MAC tags

## Testing
- `python -m pytest -q` *(fails: TclError no display name; OPENAI_API_KEY missing)*