### PR TITLE
Fix jitter computation and minor UI issue

### DIFF
--- a/AuditWifiApp/runner.py
+++ b/AuditWifiApp/runner.py
@@ -260,7 +260,6 @@ class NetworkAnalyzerUI:
 
         # Zone de statistiques - Compacte
         stats_frame = ttk.LabelFrame(control_frame, text="Statistiques", padding=5)
-        stats_frame = ttk.LabelFrame(control_frame, text="Statistiques", padding=5)
         stats_frame.pack(fill=tk.X, pady=(5, 5))
 
         # Zone de statistiques avec hauteur augmentée pour éviter le scroll


### PR DESCRIPTION
## Summary
- improve latency parsing in wifi collector to compute jitter correctly
- remove duplicate stats frame creation in main UI

## Testing
- `python -m py_compile AuditWifiApp/wifi/wifi_collector.py AuditWifiApp/runner.py`
- `PYTHONPATH=. pytest ForkliftInspectionApp/tests/test_server.py -q`
- `PYTHONPATH=. pytest -q` *(fails: no display and missing API key)*