### PR TITLE
Add ping stats to final network report

### DIFF
--- a/AuditWifiApp/RAPPORT_FINAL_README.md
+++ b/AuditWifiApp/RAPPORT_FINAL_README.md
@@ -44,6 +44,11 @@ Le rapport final comprend plusieurs sections détaillées :
   - **40-60%** : Qualité moyenne
   - **< 40%** : Qualité faible
 
+#### 📡 Analyse de la Latence (Ping & Jitter)
+- Latence moyenne et maximale
+- Valeur minimale constatée
+- Jitter moyen calculé
+
 #### 🚨 Analyse des Alertes
 - Nombre total d'alertes détectées
 - Pourcentage d'échantillons avec alertes

--- a/AuditWifiApp/runner.py
+++ b/AuditWifiApp/runner.py
@@ -1041,6 +1041,10 @@ class NetworkAnalyzerUI:
                 report += f"📅 Généré le : {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}\n"
                 report += f"📊 Échantillons analysés : {len(self.samples)}\n\n"
 
+                if 'analysis_duration_seconds' in combined_report:
+                    minutes = combined_report['analysis_duration_seconds'] / 60
+                    report += f"⏱️ Durée de l'analyse : {minutes:.1f} min\n\n"
+
                 # Section WiFi
                 if 'wifi_analysis' in combined_report and combined_report['wifi_analysis']:
                     wifi = combined_report['wifi_analysis']
@@ -1059,6 +1063,14 @@ class NetworkAnalyzerUI:
 
                     dropouts = wifi.get('dropouts', 0)
                     report += f"Déconnexions : {dropouts}\n\n"
+
+                if 'ping' in combined_report and combined_report['ping']:
+                    ping = combined_report['ping']
+                    report += "📡 STATISTIQUES PING\n"
+                    report += "-" * 20 + "\n"
+                    report += f"Latence moyenne : {ping.get('average_latency', 0):.1f} ms\n"
+                    report += f"Latence max/min : {ping.get('max_latency', 0):.1f} / {ping.get('min_latency', 0):.1f} ms\n"
+                    report += f"Jitter moyen : {ping.get('average_jitter', 0):.1f} ms\n\n"
 
                 # Section recommandations
                 if 'recommendations' in combined_report and combined_report['recommendations']:


### PR DESCRIPTION
## Summary
- track ping latency and jitter in `NetworkAnalyzer`
- show analysis duration and ping statistics in the UI report
- document latency analysis in the final report README

## Testing
- `pytest -q` *(fails: no display, missing OPENAI_API_KEY)*