### PR TITLE
Add network monitor for ping stats

### DIFF
--- a/AuditWifiApp/network_monitor.py
+++ b/AuditWifiApp/network_monitor.py
@@ -1,0 +1,101 @@
+"""Module de surveillance réseau pour l'onglet Monitoring AMR.
+
+Ce module fournit une fonction pour exécuter un ping sous Windows,
+analyse la sortie et retourne un dictionnaire contenant la latence
+moyenne, le taux de perte et un indicateur de qualité.
+
+Bonus : possibilité d'enregistrer les résultats dans un fichier CSV.
+"""
+
+from __future__ import annotations
+
+import csv
+import os
+import re
+import subprocess
+import time
+from datetime import datetime
+from typing import Dict, Optional
+
+
+PING_COUNT = "4"
+DEFAULT_IP = "192.168.1.1"
+
+
+def _parse_ping_output(output: str) -> tuple[str, str, float]:
+    """Extrait la perte et la latence moyenne depuis la sortie de ping."""
+    loss_match = re.search(r"(\d+)%\s*loss", output, re.IGNORECASE)
+    if not loss_match:
+        loss_match = re.search(r"(\d+)%\s*perte", output, re.IGNORECASE)
+    loss = loss_match.group(1) + "%" if loss_match else "100%"
+
+    avg_match = re.search(r"Average\s*=\s*([0-9]+ms)", output, re.IGNORECASE)
+    if not avg_match:
+        avg_match = re.search(r"Moyenne\s*=\s*([0-9]+ms)", output, re.IGNORECASE)
+    latency = avg_match.group(1) if avg_match else "0 ms"
+
+    loss_value = float(loss_match.group(1)) if loss_match else 100.0
+    return latency, loss, loss_value
+
+
+def _quality_emoji(loss_value: float) -> str:
+    """Retourne l'emoji correspondant à la qualité réseau."""
+    if loss_value < 2:
+        return "\U0001F535"  # 🔵
+    if loss_value <= 5:
+        return "\U0001F7E0"  # 🟠
+    return "\U0001F534"  # 🔴
+
+
+def ping_ip(ip: str = DEFAULT_IP, csv_path: Optional[str] = None) -> Dict[str, str]:
+    """Réalise un ping et retourne les statistiques utiles.
+
+    Args:
+        ip: Adresse IP à tester.
+        csv_path: Chemin d'un fichier CSV pour enregistrer le résultat.
+    """
+    try:
+        output = subprocess.check_output(
+            ["ping", "-n", PING_COUNT, ip],
+            stderr=subprocess.STDOUT,
+            universal_newlines=True,
+            encoding="utf-8",
+        )
+    except Exception:
+        # En cas d'échec, on considère 100% de perte
+        latency = "0 ms"
+        loss = "100%"
+        loss_value = 100.0
+    else:
+        latency, loss, loss_value = _parse_ping_output(output)
+
+    quality = _quality_emoji(loss_value)
+    result = {"ip": ip, "latence": latency, "perte": loss, "qualite": quality}
+
+    if csv_path:
+        _append_to_csv(csv_path, result)
+
+    return result
+
+
+def _append_to_csv(path: str, data: Dict[str, str]) -> None:
+    """Ajoute un enregistrement dans un fichier CSV."""
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    file_exists = os.path.exists(path)
+    with open(path, "a", newline="", encoding="utf-8") as csvfile:
+        writer = csv.DictWriter(
+            csvfile, fieldnames=["timestamp", "ip", "latence", "perte", "qualite"]
+        )
+        if not file_exists:
+            writer.writeheader()
+        writer.writerow({"timestamp": datetime.now().isoformat(), **data})
+
+
+def monitor(ip: str = DEFAULT_IP, interval: float = 30.0, csv_path: Optional[str] = None) -> None:
+    """Boucle de surveillance appelant ``ping_ip`` périodiquement."""
+    try:
+        while True:
+            ping_ip(ip, csv_path)
+            time.sleep(interval)
+    except KeyboardInterrupt:
+        pass

--- a/AuditWifiApp/tests/test_network_monitor.py
+++ b/AuditWifiApp/tests/test_network_monitor.py
@@ -1,0 +1,43 @@
+from unittest.mock import patch
+
+from network_monitor import ping_ip
+
+
+SAMPLE_OK = """Pinging 192.168.1.1 with 32 bytes of data:
+Reply from 192.168.1.1: bytes=32 time=10ms TTL=64
+Reply from 192.168.1.1: bytes=32 time=10ms TTL=64
+
+Ping statistics for 192.168.1.1:
+    Packets: Sent = 4, Received = 4, Lost = 0 (0% loss),
+Approximate round trip times in milli-seconds:
+    Minimum = 10ms, Maximum = 10ms, Average = 10ms
+"""
+
+SAMPLE_LOSS = """Pinging 192.168.1.1 with 32 bytes of data:
+Request timed out.
+Reply from 192.168.1.1: bytes=32 time=100ms TTL=64
+
+Ping statistics for 192.168.1.1:
+    Packets: Sent = 4, Received = 3, Lost = 1 (25% loss),
+Approximate round trip times in milli-seconds:
+    Minimum = 100ms, Maximum = 100ms, Average = 100ms
+"""
+
+
+def test_ping_success_parsing():
+    with patch("network_monitor.subprocess.check_output", return_value=SAMPLE_OK):
+        result = ping_ip("192.168.1.1")
+    assert result["perte"] == "0%"
+    assert result["latence"] == "10ms"
+    assert result["qualite"] == "\U0001F535"
+
+
+def test_ping_packet_loss_parsing():
+    with patch(
+        "network_monitor.subprocess.check_output",
+        return_value=SAMPLE_LOSS,
+    ):
+        result = ping_ip("192.168.1.1")
+    assert result["perte"] == "25%"
+    assert result["latence"] == "100ms"
+    assert result["qualite"] == "\U0001F534"


### PR DESCRIPTION
## Summary
- add `network_monitor.py` with ping statistics and CSV logging
- include new tests for the monitor

## Testing
- `PYTHONPATH=$PWD pytest -q` *(fails: missing display and OPENAI API environment)*